### PR TITLE
Update path to homepage logo for German translation

### DIFF
--- a/content/template-parts/about-lindas/de.md
+++ b/content/template-parts/about-lindas/de.md
@@ -2,4 +2,4 @@
 
 Mit LINDAS (Linked Data Service) können öffentliche Verwaltungen ihre Daten in Form von *Knowledge Graphs* veröffentlichen und diese über https://lindas.admin.ch zugänglich machen. Datennutzerinnen und Datennutzer können dann auf diese Daten über eine Vielzahl von [Möglichkeiten](/data-usage/data-usage-types) zugreifen. LINDAS wird vom [Schweizerischen Bundesarchiv](https://www.bar.admin.ch/bar/de/home.html) betrieben und umfasst verschiedene [Elemente des Datenlebenszyklus](/ecosystem/LINDAS-ecosystem).
 
-![LINDAS Logo](/static/img/lindaslogo_web.png)
+![LINDAS Logo](/static-assets/img/lindaslogo_web.png)


### PR DESCRIPTION
The German homepage is using a broken path to the logo.
This PR is fixing this issue.