### PR TITLE
Query using a specific format using GET

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -124,6 +124,12 @@ plugins:
       endpointUrl: env:SPARQL_ENDPOINT_URL
       username: env:SPARQL_USERNAME
       password: env:SPARQL_PASSWORD
+      formats:
+        ttl: "text/turtle"
+        nt: "application/n-triples"
+        xml: "application/rdf+xml"
+        jsonld: "application/ld+json"
+        csv: "text/csv"
 
   menu:
     module: file:plugins/menu/index.js


### PR DESCRIPTION
Allow a user to perform a SPARQL query on the `/query` endpoint using GET, and receive the response in a specific format.

Supported values for the `format` query parameter:

| `format` | MIME type               |
| -------- | ----------------------- |
| `ttl`    | "text/turtle"           |
| `nt`     | "application/n-triples" |
| `xml`    | "application/rdf+xml"   |
| `jsonld` | "application/ld+json"   |
| `csv`    | "text/csv"              |

Ping @l00mi 