### PR TITLE
Validate local config using the schema

### DIFF
--- a/config.local.yaml
+++ b/config.local.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://unpkg.com/trifid-core@latest/lib/config/schema.json
+
 extends:
   - config.yaml
 


### PR DESCRIPTION
This helps IDE to catch issues with the configuration file.

This was already enabled for the base and norewrite files.