### PR TITLE
Xkey - decode CubeIRI

### DIFF
--- a/plugins/xquery/index.js
+++ b/plugins/xquery/index.js
@@ -68,7 +68,9 @@ const cleanupHeaderValue = (headerValue, defaultValue) => {
   if (newValue.length > 256) {
     return defaultValue
   }
-  return newValue
+
+  // Support URL encoded values
+  return decodeURIComponent(newValue)
 }
 
 export default factory


### PR DESCRIPTION
In case the CubeIRI is provided using urlencoded values, the xkey header should be urldecoded.