### PR TITLE
Mention `trig` file format in the URL parameter documentation

### DIFF
--- a/content/data-usage/data-usage-types/default.md
+++ b/content/data-usage/data-usage-types/default.md
@@ -144,6 +144,7 @@ Supported values for the format query parameter:
 | xml    | application/rdf+xml   |
 | jsonld | application/ld+json   |
 | csv    | text/csv              |
+| trig   | application/trig      |
 
 ## Example Usage
 


### PR DESCRIPTION
The section "What other file parameters can be used?" mentions only `ttl`, `nt`, `xml`, `json-ld` and `csv`, but not `trig`, which is actually working (e.g. <https://register.ld.admin.ch/zefix/company/1118792?format=trig>). This may be relevant if one wishes to decompose the triples by graph.